### PR TITLE
Adding init script to copy giles executor to the solution dir on install.

### DIFF
--- a/giles.ps1
+++ b/giles.ps1
@@ -1,0 +1,8 @@
+param(
+  [Parameter(Position=0,Mandatory=0)]
+  [string]$solutionFile = "$(Split-Path $pwd -leaf).sln"
+)
+
+$solutionFile = Resolve-Path $solutionFile
+$giles = @(Get-ChildItem .\* -recurse -include giles.exe)[0].FullName
+& $giles -s $solutionFile

--- a/init.ps1
+++ b/init.ps1
@@ -1,0 +1,9 @@
+param($rootPath, $toolsPath, $package, $project)
+
+$gilesRunnerFrom = $toolsPath + "\giles.ps1"
+$gilesRunnerTo = "giles.ps1"
+
+if(!(Test-Path $gilesRunnerTo))
+{
+  Copy-Item $gilesRunnerFrom $gilesRunnerTo
+}

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -43,7 +43,10 @@ desc "Prep the package folder"
 task :prepPackage do
 	FileSystem.DeleteDirectory("deploy")
 	FileSystem.EnsurePath("deploy/package")
+	FileSystem.EnsurePath("deploy/package/tools")
 	FileSystem.CopyFiles("build/*", "deploy/package")
+	FileSystem.CopyFiles("giles.ps1", "deploy/package/tools")
+	FileSystem.CopyFiles("init.ps1", "deploy/package/tools")
 end
 
 desc "Create the nuspec"


### PR DESCRIPTION
Now users can just do

install-package giles
.\giles

and it is up and running.
