### PR TITLE
Fixing xunit detection

### DIFF
--- a/src/Giles.Core/AppDomains/GilesAppDomainManager.cs
+++ b/src/Giles.Core/AppDomains/GilesAppDomainManager.cs
@@ -124,7 +124,7 @@ namespace Giles.Core.AppDomains
 
         private static IEnumerable<string> GetGilesAssembliesToUse()
         {
-            var runners = TestFrameworkResolver.GetNewInstancesByType<IFrameworkRunner>();
+            var runners = TypeLoader.GetNewInstancesByType<IFrameworkRunner>();
 
             var result = new List<string> { typeof(GilesAppDomainRunner).Assembly.Location };
 

--- a/src/Giles.Core/Configuration/TestAssemblyFinder.cs
+++ b/src/Giles.Core/Configuration/TestAssemblyFinder.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Giles.Core.IO;
+using Giles.Core.Runners;
 
 namespace Giles.Core.Configuration
 {
@@ -16,6 +18,14 @@ namespace Giles.Core.Configuration
             @"Project\(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC\}""\)" +
             @"[^""]*""[^""]*""" + 
             @"[^""]*""([^""]*)""", RegexOptions.Compiled);
+
+        private static readonly string[] SupportedAssemblies
+                = new[]
+                  {
+                          "Machine.Specifications.dll",
+                          "nunit.framework.dll",
+                          "xunit.dll"
+                  };
 
         public TestAssemblyFinder(IFileSystem fileSystem)
         {
@@ -66,11 +76,10 @@ namespace Giles.Core.Configuration
         private int GetIsTestProjectScore(MsBuildProject project)
         {
             // TODO: may want to group this information with other info about supported test frameworks
-            int score = 0;
-            if (IsTestFrameworkReferenced(project, "Machine.Specifications.dll"))
-                score += 10;
-            if (IsTestFrameworkReferenced(project, "nunit.framework.dll"))
-                score += 10;
+            int numberOfReferencedTestAssemblies =
+                    SupportedAssemblies.Where( item => IsTestFrameworkReferenced( project, item ) )
+                            .Count();
+            int score = numberOfReferencedTestAssemblies * 10;
 
             // no supported test framework, abort
             if (score == 0)

--- a/src/Giles.Core/Giles.Core.csproj
+++ b/src/Giles.Core/Giles.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Runners\TestResult.cs" />
     <Compile Include="Runners\TestRunner.cs" />
     <Compile Include="Runners\TestFrameworkResolver.cs" />
+    <Compile Include="Utility\TypeLoader.cs" />
     <Compile Include="UI\ConsoleUserDisplay.cs" />
     <Compile Include="UI\GrowlUserDisplay.cs" />
     <Compile Include="UI\IUserDisplay.cs" />

--- a/src/Giles.Core/Utility/TypeLoader.cs
+++ b/src/Giles.Core/Utility/TypeLoader.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Giles.Core.Utility
+{
+    public class TypeLoader
+    {
+        /// <summary>
+        /// Gets a list of new instances of classes which implement, extend or are of type T
+        /// from all of the assemblies in the executing path
+        /// </summary>
+        /// <returns>List of new instances of classes which implement, extend or are of type T</returns>
+        public static IEnumerable<T> GetNewInstancesByType<T>() where T : class
+        {
+            var files = AssemblyExtensions.GetAssembliesFromExecutingPath();
+
+            var result = new List<T>();
+
+            files.Each( file => result.AddRange( AssemblyExtensions.FromAssemblyGetInstancesOfType<T>( file ) ) );
+
+            return result;
+        }
+    }
+}

--- a/src/Runners/Giles.Runner.XUnit/XunitTestRunner.cs
+++ b/src/Runners/Giles.Runner.XUnit/XunitTestRunner.cs
@@ -20,8 +20,7 @@ namespace Giles.Runner.Xunit {
         {
             return new[]
                        {
-                           Assembly.GetAssembly(typeof(XunitTestRunner)).Location, 
-                           "xunit.runner.utility.dll"
+                           Assembly.GetAssembly(typeof(XunitTestRunner)).Location, "xunit.runner.utility.dll"
                        };
         }
     }


### PR DESCRIPTION
Somehow xunit was no longer being scored when assemblies were being considered. This fixes the issue and pulls the available frameworks into a central location. I wanted to leverage the assembly requirements code, but it uses AssemblyName instead of strings. I think that it can be refactored further so that we have all project requirements in a central piece of logic.
