### PR TITLE
Fixing issue 12 for nunit.

### DIFF
--- a/src/Runners/Giles.Runner.NUnit/DomainRunner.cs
+++ b/src/Runners/Giles.Runner.NUnit/DomainRunner.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using NUnit.Core;
+using NUnit.Util;
+
+namespace Giles.Runner.NUnit
+{
+    public class DomainRunner : ProxyTestRunner
+    {
+        private DomainAgent agent;
+
+        private AppDomain domain;
+
+        public DomainRunner()
+                : this( 0 )
+        {
+        }
+
+        public DomainRunner( int runnerId )
+                : base( runnerId )
+        {
+            DomainManager = new DomainManager();
+        }
+
+        private DomainManager DomainManager { get; set; }
+
+        public override bool Load( TestPackage package )
+        {
+            Unload();
+
+            try
+            {
+                if ( domain == null )
+                {
+                    domain = DomainManager.CreateDomain( package );
+                }
+
+                if ( agent == null )
+                {
+                    agent = DomainAgent.CreateInstance( domain );
+                    agent.Start();
+                }
+
+                if ( TestRunner == null )
+                {
+                    TestRunner = agent.CreateRunner( ID );
+                }
+
+                return TestRunner.Load( package );
+            }
+            catch
+            {
+                Unload();
+                throw;
+            }
+        }
+
+        public override void Unload()
+        {
+            if ( TestRunner != null )
+            {
+                TestRunner.Unload();
+                TestRunner = null;
+            }
+
+            if ( agent != null )
+            {
+                agent.Dispose();
+                agent = null;
+            }
+
+            if ( domain != null )
+            {
+                DomainManager.Unload( domain );
+                domain = null;
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            Unload();
+        }
+    }
+}

--- a/src/Runners/Giles.Runner.NUnit/Giles.Runner.NUnit.csproj
+++ b/src/Runners/Giles.Runner.NUnit/Giles.Runner.NUnit.csproj
@@ -40,6 +40,9 @@
     <Reference Include="nunit.core.interfaces">
       <HintPath>..\..\..\lib\NUnit.2.5.10.11092\tools\lib\nunit.core.interfaces.dll</HintPath>
     </Reference>
+    <Reference Include="nunit.util">
+      <HintPath>..\..\..\lib\NUnit.2.5.10.11092\tools\lib\nunit.util.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
@@ -48,6 +51,7 @@
     <Compile Include="..\..\ProjectVersion.cs">
       <Link>Properties\ProjectVersion.cs</Link>
     </Compile>
+    <Compile Include="DomainRunner.cs" />
     <Compile Include="GilesNUnitEventListener.cs" />
     <Compile Include="NUnitTestFrameworkInspector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Runners/Giles.Runner.NUnit/GilesNUnitEventListener.cs
+++ b/src/Runners/Giles.Runner.NUnit/GilesNUnitEventListener.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Giles.Core.Runners;
 using NUnit.Core;
 using TestResult = NUnit.Core.TestResult;
 
 namespace Giles.Runner.NUnit
 {
-    public class GilesNUnitEventListener : EventListener
+    [Serializable]
+    public class GilesNUnitEventListener : MarshalByRefObject, EventListener
     {
         const string _testRunnerName = "NUNIT";
         private readonly SessionResults sessionResults = new SessionResults();

--- a/src/Runners/Giles.Runner.NUnit/NUnitRunner.cs
+++ b/src/Runners/Giles.Runner.NUnit/NUnitRunner.cs
@@ -1,34 +1,84 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Giles.Core.Runners;
 using NUnit.Core;
 
 namespace Giles.Runner.NUnit
 {
+    [Serializable]
     public class NUnitRunner : IFrameworkRunner
     {
-        public SessionResults RunAssembly(Assembly assembly)
+        #region IFrameworkRunner Members
+
+        public SessionResults RunAssembly( Assembly assembly )
         {
-            var remoteTestRunner = new RemoteTestRunner(0);
-            var package = SetupTestPackager(assembly);
-            remoteTestRunner.Load(package);
-            var listener = new GilesNUnitEventListener();
-            remoteTestRunner.Run(listener);
-            return listener.SessionResults;
+            using (var domainRunner = new DomainRunner())
+            {
+                TestPackage package = SetupTestPackager( assembly );
+                domainRunner.Load( package );
+                var listener = new GilesNUnitEventListener();
+                domainRunner.Run( listener );
+                return listener.SessionResults;
+            }
         }
 
         public IEnumerable<string> RequiredAssemblies()
         {
             return new[]
-                       {
-                           Assembly.GetAssembly(typeof(NUnitRunner)).Location, 
-                           "nunit.core.dll", "nunit.core.interfaces.dll"
-                       };
+                   {
+                           Assembly.GetAssembly( typeof (NUnitRunner) ).Location,
+                           "nunit.core.dll", "nunit.core.interfaces.dll", "nunit.util.dll"
+                   };
         }
+
+        #endregion
 
         private static TestPackage SetupTestPackager(Assembly assembly)
         {
-            return new TestPackage(assembly.FullName, new[] { assembly.Location });
+            var package = new TestPackage(assembly.FullName, new[] { assembly.Location });
+
+            package.BasePath = GetAssemblyDirectory(assembly).FullName;
+            package.ConfigurationFile = GetTestAssemblyConfigurationFile(assembly);
+
+            return package;
+        }
+
+        private static string GetTestAssemblyConfigurationFile( Assembly assembly )
+        {
+            string configFileName = GetTestAssemblyConfigurationFullName( assembly );
+            configFileName = File.Exists( configFileName ) ? configFileName : null;
+            return configFileName;
+        }
+
+        private static string GetTestAssemblyConfigurationFileName(Assembly assembly)
+        {
+            string assemblyPath = GetAssemblyFullPath(assembly);
+            var fileName = Path.GetFileName(assemblyPath);
+            string configFileName = string.Format("{0}.config", fileName);
+            return configFileName;
+        }
+
+        private static string GetTestAssemblyConfigurationFullName(Assembly assembly)
+        {
+            string assemblyDirectory = GetAssemblyDirectory(assembly).FullName;
+            string configFileName = GetTestAssemblyConfigurationFileName(assembly);
+            configFileName = Path.Combine(assemblyDirectory, configFileName);
+            return configFileName;
+        }
+
+        private static DirectoryInfo GetAssemblyDirectory(Assembly assembly)
+        {
+            string assemblyPath = GetAssemblyFullPath(assembly);
+            var directory = new FileInfo(assemblyPath).Directory;
+            return directory;
+        }
+
+        private static string GetAssemblyFullPath(Assembly assembly)
+        {
+            string assemblyPath = new Uri(assembly.CodeBase).LocalPath;
+            return assemblyPath;
         }
     }
 }


### PR DESCRIPTION
 Test runs must occur in a child AppDomain properly configured for the app.config file mapping. Test listener must be MarshalByRefObject in order to cross AppDomain boundaries.
