### PR TITLE
Adding colored Pass/Fail/Ignore messages to the console

### DIFF
--- a/src/Giles.Core/Giles.Core.csproj
+++ b/src/Giles.Core/Giles.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Runners\TestResult.cs" />
     <Compile Include="Runners\TestFrameworkResolver.cs" />
     <Compile Include="UI\DisplayScrubber.cs" />
+    <Compile Include="Utility\CollectionExtensions.cs" />
     <Compile Include="Utility\TypeLoader.cs" />
     <Compile Include="UI\ConsoleUserDisplay.cs" />
     <Compile Include="UI\GrowlUserDisplay.cs" />

--- a/src/Giles.Core/Runners/BuildRunner.cs
+++ b/src/Giles.Core/Runners/BuildRunner.cs
@@ -42,7 +42,7 @@ namespace Giles.Core.Runners
                                         result.ExitCode == 0 ? "Success" : "Failure");
 
             if (result.ExitCode != 0)
-                message += string.Format("\n{0}", result.Output);
+                message += string.Format("\n{0}", result.ErrorMessage);
             return message;
         }
     }

--- a/src/Giles.Core/Runners/CommandProcessExecutor.cs
+++ b/src/Giles.Core/Runners/CommandProcessExecutor.cs
@@ -47,16 +47,45 @@ namespace Giles.Core.Runners
             return new ExecutionResult
                        {
                            ExitCode = exitCode, 
-                           Output = output, 
-                           Runner = new FileInfo(fileName).Name.ToUpper().Replace(".EXE", string.Empty)
+                           Runner = new TestRunnerResult
+                           {
+                               RunnerName = new FileInfo(fileName).Name.ToUpper().Replace(".EXE", string.Empty)
+                           }
                        };
         }
     }
 
     public class ExecutionResult
     {
-        public string Runner { get; set; }
-        public string Output { get; set; }
+        public ExecutionResult()
+        {
+            Runner = new TestRunnerResult();
+        }
+        public TestRunnerResult Runner { get; set; }
+        public string ErrorMessage { get; set; }
         public int ExitCode { get; set; }
+    }
+
+    public class TestRunnerResult
+    {
+        public TestRunnerResult()
+        {
+            Stats = new TestStatistics();
+        }
+
+        public string RunnerName { get; set; }
+        public TestStatistics Stats { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("{0} Passed: {1}, Failed: {2}, Ignored: {3}", RunnerName, Stats.Passed, Stats.Failed, Stats.Ignored);
+        }
+    }
+
+    public class TestStatistics
+    {
+        public int Passed { get; set; }
+        public int Failed { get; set; }
+        public int Ignored { get; set; }
     }
 }

--- a/src/Giles.Core/UI/ConsoleUserDisplay.cs
+++ b/src/Giles.Core/UI/ConsoleUserDisplay.cs
@@ -11,6 +11,7 @@ namespace Giles.Core.UI
         {
             defaultConsoleColor = Console.ForegroundColor;
         }
+
         public void DisplayMessage(string message, params object[] parameters)
         {
             Console.WriteLine(message.ScrubDisplayStringForFormatting(), parameters);
@@ -18,13 +19,66 @@ namespace Giles.Core.UI
 
         public void DisplayResult(ExecutionResult result)
         {
-            Console.WriteLine("\n\n======= {0} TEST RUNNER RESULTS =======", result.Runner);
-            Console.ForegroundColor = result.ExitCode != 0 ?
-                                      ConsoleColor.Red : defaultConsoleColor;
+            try
+            {
+                Console.WriteLine("\n\n======= {0} TEST RUNNER RESULTS =======", result.Runner.RunnerName);
 
-            Console.WriteLine(result.Output);
+                using(new ChangedColorContext(GetPassedColor(result)))
+                {
+                    Console.Write(string.Format("Passed: {0}", result.Runner.Stats.Passed));
+                }
 
-            Console.ForegroundColor = defaultConsoleColor;
+                Console.Write(", ");
+
+                using (new ChangedColorContext(GetFailedColor(result)))
+                {
+                    Console.Write(string.Format("Failed: {0}", result.Runner.Stats.Failed));
+                }
+
+                Console.Write(", ");
+
+                using (new ChangedColorContext(GetIgnoredColor(result)))
+                {
+                    Console.Write(string.Format("Ignored: {0}", result.Runner.Stats.Ignored));
+                }
+
+                Console.Write(Environment.NewLine);
+            }
+            finally
+            {
+                Console.ForegroundColor = defaultConsoleColor;
+            }
+        }
+
+        public ConsoleColor GetPassedColor(ExecutionResult result)
+        {
+            return result.Runner.Stats.Passed > 0 ? ConsoleColor.Green : defaultConsoleColor;
+        }
+
+        public ConsoleColor GetFailedColor(ExecutionResult result)
+        {
+            return result.Runner.Stats.Failed > 0 ? ConsoleColor.Red : defaultConsoleColor;
+        }
+
+        public ConsoleColor GetIgnoredColor(ExecutionResult result)
+        {
+            return result.Runner.Stats.Ignored > 0 ? ConsoleColor.Yellow : defaultConsoleColor;
+        }
+
+        private class ChangedColorContext : IDisposable
+        {
+            private readonly ConsoleColor defaultConsoleColor;
+
+            public ChangedColorContext(ConsoleColor color)
+            {
+                defaultConsoleColor = Console.ForegroundColor;
+                Console.ForegroundColor = color;
+            }
+
+            public void Dispose()
+            {
+                Console.ForegroundColor = defaultConsoleColor;
+            }
         }
     }
 }

--- a/src/Giles.Core/UI/GrowlUserDisplay.cs
+++ b/src/Giles.Core/UI/GrowlUserDisplay.cs
@@ -45,7 +45,7 @@ namespace Giles.Core.UI
         {
             var title = result.ExitCode == 0 ? "Success!" : "Failures!";
             Resource icon = result.ExitCode == 0 ? LoadImage(successImage) : LoadImage(failureImage);
-            var notification = new Notification(application.Name, notificationType.Name, DateTime.Now.Ticks.ToString(), title, result.Output) { Icon = icon };
+            var notification = new Notification(application.Name, notificationType.Name, DateTime.Now.Ticks.ToString(), title, result.Runner.ToString()) { Icon = icon };
             growl.Notify(notification);
         }
 

--- a/src/Giles.Core/Utility/CollectionExtensions.cs
+++ b/src/Giles.Core/Utility/CollectionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Giles.Core.Utility
+{
+    public static class CollectionExtensions
+    {
+        public static bool IsNullOrEmpty<T>(this IList<T> list)
+        {
+            return list == null || list.Count == 0;
+        }
+    }
+}

--- a/src/Giles.Specs/Core/Runners/GilesTestListenerSpecs.cs
+++ b/src/Giles.Specs/Core/Runners/GilesTestListenerSpecs.cs
@@ -70,13 +70,13 @@ namespace Giles.Specs.Core.Runners
             fakeUserDisplay.DisplayResultsReceived.ShouldNotBeEmpty();
 
         It should_display_the_number_of_successful_tests = () =>
-            fakeUserDisplay.DisplayResultsReceived.Count(x => x.Output.Contains("Passed: 0")).ShouldEqual(1);
+            fakeUserDisplay.DisplayResultsReceived.Count(x => x.Runner.ToString().Contains("Passed: 0")).ShouldEqual(1);
 
         It should_display_the_number_of_failed_tests = () =>
-            fakeUserDisplay.DisplayResultsReceived.Count(x => x.Output.Contains("Failed: 1")).ShouldEqual(1);
+            fakeUserDisplay.DisplayResultsReceived.Count(x => x.Runner.ToString().Contains("Failed: 1")).ShouldEqual(1);
 
         It should_display_the_number_of_ignored_tests = () =>
-            fakeUserDisplay.DisplayResultsReceived.Count(x => x.Output.Contains("Ignored: 0")).ShouldEqual(1);
+            fakeUserDisplay.DisplayResultsReceived.Count(x => x.Runner.ToString().Contains("Ignored: 0")).ShouldEqual(1);
 
     }
 


### PR DESCRIPTION
It was a bit hard to decide the status of the test run at one glance. I've added the gree/red/yellow colors to test results so when you see a part of the test result message in red, you know something has failed. Here's how it looks, if you're interested: http://twitpic.com/9oip17
