### PR TITLE
Created different Growl notification types for information, success, and...

### DIFF
--- a/src/Giles.Core/UI/GrowlUserDisplay.cs
+++ b/src/Giles.Core/UI/GrowlUserDisplay.cs
@@ -10,7 +10,9 @@ namespace Giles.Core.UI
     public class GrowlUserDisplay : IUserDisplay
     {
         private GrowlConnector growl;
-        private NotificationType notificationType;
+        private NotificationType informationNotificationType;
+        private NotificationType successNotificationType;
+        private NotificationType failureNotificationType;
         private Application application;
         private const string successImage = "Giles.Core.Resources.checkmark.png";
         private const string failureImage = "Giles.Core.Resources.stop.png";
@@ -22,7 +24,10 @@ namespace Giles.Core.UI
 
         void Initialize()
         {
-            notificationType = new NotificationType("BUILD_RESULT_NOTIFICATION", "Sample Notification");
+            informationNotificationType = new NotificationType("BUILD_RESULT_NOTIFICATION", "Sample Notification");
+            successNotificationType = new NotificationType("SUCCESS_NOTIFICATION", "Success Notification");
+            failureNotificationType = new NotificationType("FAILURE_NOTIFICATION", "Failure Notification");
+
             application = new Application("Giles");
             growl = new GrowlConnector
                         {
@@ -30,22 +35,31 @@ namespace Giles.Core.UI
                         };
 
 
-            growl.Register(application, new[] { notificationType });
+            growl.Register(application,
+                new[] {
+                    informationNotificationType,
+                    successNotificationType,
+                    failureNotificationType
+                });
         }
 
         public void DisplayMessage(string message, params object[] parameters)
         {
             const string title = "Giles says...";
             var text = string.Format(message.ScrubDisplayStringForFormatting(), parameters);
-            var notification = new Notification(application.Name, notificationType.Name, DateTime.Now.Ticks.ToString(), title, text);
+            var notification = new Notification(application.Name, informationNotificationType.Name, DateTime.Now.Ticks.ToString(), title, text);
             growl.Notify(notification);
         }
 
         public void DisplayResult(ExecutionResult result)
         {
-            var title = result.ExitCode == 0 ? "Success!" : "Failures!";
+            var isSuccess = result.ExitCode == 0;
+
+            var title = isSuccess ? "Success!" : "Failures!";
+            var notifyType = isSuccess ? successNotificationType : failureNotificationType;
+
             Resource icon = result.ExitCode == 0 ? LoadImage(successImage) : LoadImage(failureImage);
-            var notification = new Notification(application.Name, notificationType.Name, DateTime.Now.Ticks.ToString(), title, result.Runner.ToString()) { Icon = icon };
+            var notification = new Notification(application.Name, notifyType.Name, DateTime.Now.Ticks.ToString(), title, result.Runner.ToString()) { Icon = icon };
             growl.Notify(notification);
         }
 


### PR DESCRIPTION
I started using Giles + Growl, but was quickly annoyed by how often I got Growl notifications. I only wanted test success and failure messages. So I added different notification types so I could customize how Growl displays them in the Growl user interface.
